### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "lodash": "^4.17.21",
     "multer": "^1.4.5-lts.1",
     "node-localstorage": "^3.0.5",
-    "winston": "^3.17.0"
+    "winston": "^3.17.0",
+    "express-rate-limit": "^7.5.0"
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ryck/scrobblex/security/code-scanning/1](https://github.com/ryck/scrobblex/security/code-scanning/1)

To fix the problem, we will introduce a rate-limiting middleware using the `express-rate-limit` package. This middleware will limit the number of requests to the `/authorize` endpoint to a reasonable number within a specified time window. This will help prevent abuse and potential DoS attacks.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `src/index.js` file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum of 100 requests per 15 minutes).
4. Apply the rate limiter to the `/authorize` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
